### PR TITLE
OPL: Rename PS2RD=1 to CHEAT=1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,10 @@ script:
  - make GSM=1
  - cp OPNPS2LD.ELF out/OPL_GSM/OPNPS2LD-GSM.ELF
  - make clean
- - make PS2RD=1
+ - make CHEAT=1
  - cp OPNPS2LD.ELF out/OPL_PS2RD/OPNPS2LD-PS2RD.ELF
  - make clean
- - make GSM=1 PS2RD=1 PADEMU=1 IGS=1
+ - make GSM=1 CHEAT=1 PADEMU=1 IGS=1
  - cp OPNPS2LD.ELF out/OPL_GSM+PS2RD+PADEMU+IGS/OPNPS2LD-GSM+PS2RD+PADEMU+IGS.ELF
  - make clean
  - make VMC=1
@@ -95,7 +95,7 @@ script:
  - make VMC=1 GSM=1
  - cp OPNPS2LD.ELF out/OPL_VMC+GSM/OPNPS2LD-VMC+GSM.ELF
  - make clean
- - make VMC=1 PS2RD=1
+ - make VMC=1 CHEAT=1
  - cp OPNPS2LD.ELF out/OPL_VMC+PS2RD/OPNPS2LD-VMC+PS2RD.ELF
  - make clean
  - make release


### PR DESCRIPTION
PS2RD builds previously lacked PS2RD functionality because they were using "PS2RD" as a config variable. OPL's makefile uses "CHEAT" to for that feature.

These changes should restore PS2RD functionality to all builds that are meant to have it.

**PS:** This PR hasn't been tested. But its changes are so straightforward that it's unlikely to cause any issues.